### PR TITLE
[WIP] Fix compiling errors under Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ add_definitions("-Wall -Wextra")
 
 # Once CMake 3.1 is required, you can replace this with CMAKE_CXX_STANDARD
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "--std=gnu++11 ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "--std=gnu++17 ${CMAKE_CXX_FLAGS}")
 endif()
 
 find_package(SDL2 2.0.0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CALICO_SOURCES
                     jagpad.h
     j_eeprom.c
                     keywords.h
-    m_argv.c        m_argv.h
     m_main.c
                     music.h
     o_main.c
@@ -76,6 +75,7 @@ set(ELIB_SOURCES
                         elib/dllist.h
                         elib/elib.h
                         elib/m_ctype.h
+    elib/m_argv.c       elib/m_argv.h
     elib/misc.cpp       elib/misc.h
     elib/parser.cpp     elib/parser.h
     elib/qstring.cpp    elib/qstring.h

--- a/src/posix/posix_platform.cpp
+++ b/src/posix/posix_platform.cpp
@@ -135,7 +135,9 @@ static hal_bool POSIX_FileExists(const char *path)
     qstring normpath { path };
     normpath.normalizeSlashes();
 
-    return (!stat(normpath.constPtr(), &st) && !S_ISDIR(st.st_mode));
+    if (!stat(normpath.constPtr(), &st) && !S_ISDIR(st.st_mode))
+        return HAL_TRUE;
+    return HAL_FALSE;
 }
 
 //


### PR DESCRIPTION
This PR fixes compiler errors when compiling under Ubuntu 20.04, although linking errors remain. I don't know what causes them. 

Do you have an idea?

```
[100%] Linking CXX executable calico-doom
/usr/bin/ld: CMakeFiles/calico-doom.dir/am_main.c.o: in function `AM_Start':
/home/ax/git/calico-doom/src/am_main.c:65: undefined reference to `g_renderer'
/usr/bin/ld: CMakeFiles/calico-doom.dir/am_main.c.o: in function `AM_Drawer':
/home/ax/git/calico-doom/src/am_main.c:336: undefined reference to `g_renderer'
/usr/bin/ld: CMakeFiles/calico-doom.dir/f_main.c.o: in function `BufferedDrawSprite':
/home/ax/git/calico-doom/src/f_main.c:68: undefined reference to `g_renderer'
/usr/bin/ld: /home/ax/git/calico-doom/src/f_main.c:69: undefined reference to `g_renderer'
/usr/bin/ld: CMakeFiles/calico-doom.dir/jagonly.c.o: in function `Jag68k_main':
/home/ax/git/calico-doom/src/jagonly.c:112: undefined reference to `g_renderer'
/usr/bin/ld: CMakeFiles/calico-doom.dir/jagonly.c.o:/home/ax/git/calico-doom/src/jagonly.c:113: more undefined references to `g_renderer' follow
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o: in function `GL_RenderFrame()':
/home/ax/git/calico-doom/src/gl/gl_render.cpp:131: undefined reference to `GL_ExecuteDrawCommands()'
/usr/bin/ld: /home/ax/git/calico-doom/src/gl/gl_render.cpp:132: undefined reference to `GL_ClearDrawCommands()'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o: in function `GL_InitRenderer(int, int)':
/home/ax/git/calico-doom/src/gl/gl_render.cpp:144: undefined reference to `GL_SetDrawCommandFunc(void (*)(int, int, unsigned int, unsigned int, rbTexture&))'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o: in function `GL_SelectRenderer()':
/home/ax/git/calico-doom/src/gl/gl_render.cpp:193: undefined reference to `g_renderer'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x8): undefined reference to `GL_InitFramebufferTextures()'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x10): undefined reference to `GL_GetFramebuffer(glfbwhich_e)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x18): undefined reference to `GL_UpdateFramebuffer(glfbwhich_e)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x20): undefined reference to `GL_ClearFramebuffer(glfbwhich_e, unsigned int)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x28): undefined reference to `GL_FramebufferSetUpdated(glfbwhich_e)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x30): undefined reference to `GL_AddFramebuffer(glfbwhich_e)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x40): undefined reference to `GL_NewTextureResource(char const*, void*, unsigned int, unsigned int, glrestype_e, int)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x48): undefined reference to `GL_TextureResourceGetFramebuffer(glfbwhich_e)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x50): undefined reference to `GL_CheckForTextureResource(char const*)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x58): undefined reference to `GL_UpdateTextureResource(void*)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x60): undefined reference to `GL_TextureResourceSetUpdated(void*)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x68): undefined reference to `GL_GetTextureResourceStore(void*)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x70): undefined reference to `GL_ClearTextureResource(void*, unsigned int)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x78): undefined reference to `GL_AddDrawCommand(void*, int, int, unsigned int, unsigned int)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/gl/gl_render.cpp.o:(.data.rel+0x80): undefined reference to `GL_AddLateDrawCommand(void*, int, int, unsigned int, unsigned int)'
/usr/bin/ld: CMakeFiles/calico-doom.dir/sdl/sdl_video.cpp.o: in function `SDL2_setRenderer()':
/home/ax/git/calico-doom/src/sdl/sdl_video.cpp:132: undefined reference to `GL4_SelectRenderer()'
/usr/bin/ld: /home/ax/git/calico-doom/src/sdl/sdl_video.cpp:137: undefined reference to `g_renderer'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/calico-doom.dir/build.make:1349: src/calico-doom] Error 1
make[1]: *** [CMakeFiles/Makefile2:94: src/CMakeFiles/calico-doom.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```